### PR TITLE
Add branching guidelines and CONTRIBUTING doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+Thank you for your interest in improving this project!
+
+## Branching Strategy
+
+- **main**: Stable branch. All production-ready code lives here.
+- **feature branches**: Start new work from `main` using short-lived branches. Merge back via pull request.
+
+## Development Workflow
+
+1. Create a feature branch off `main`.
+2. Make your changes and commit them with descriptive messages.
+3. Verify quality by running:
+   ```
+   make lint
+   make test
+   ```
+4. Push your branch and open a pull request targeting `main`.
+5. A project maintainer will review your PR before merging.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,14 @@ This project provides a scaffolding for multiple services that work together via
 1. Ensure you have Docker and Docker Compose installed.
 2. Clone the repository and run `make build` to build the service images.
 3. Start the stack with `make up`.
-4. Stop services with `make down`.
-5. Run tests locally with `make test` and lint with `make lint`.
+  4. Stop services with `make down`.
+  5. Run tests locally with `make test` and lint with `make lint`.
+
+## Branching Strategy
+
+Development happens on short-lived feature branches created from the
+`main` branch. The `main` branch always contains stable code and is
+where pull requests should target when merging new features or fixes.
 
 ## Development Workflow
 


### PR DESCRIPTION
## Summary
- describe the branching strategy in README
- add CONTRIBUTING.md with workflow instructions

## Testing
- `make lint` *(fails: missing separator in Makefile)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684aaaf7e9708323935b3a59cc4ae9ff