### PR TITLE
Add Dockerfile for graph service

### DIFF
--- a/services/graph/Dockerfile
+++ b/services/graph/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+CMD ["python", "-c", "print('graph service placeholder')"]


### PR DESCRIPTION
## Summary
- add minimal Dockerfile so the graph service can build

## Testing
- `make build` *(fails: docker-compose not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684aca09009c8323ac62c097f6eae640