### PR TITLE
Add httpx dependency

### DIFF
--- a/services/ingest/requirements.txt
+++ b/services/ingest/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+httpx


### PR DESCRIPTION
## Summary
- add `httpx` to ingest service requirements

## Testing
- `pip install -r services/ingest/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684acab7daa883238c64815d13c505da