### PR TITLE
Add shared requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This project provides a scaffolding for multiple services that work together via
    ```
    python -m venv venv
    source venv/bin/activate
-   pip install -r services/ingest/requirements.txt
+   pip install -r requirements.txt
+   pip install -r services/ingest/requirements.txt  # service-specific
    ```
 4. Build the service images with `make build`.
 5. Start the stack with `make up` and stop it with `make down`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+httpx
+uvicorn


### PR DESCRIPTION
## Summary
- add a top-level `requirements.txt` for FastAPI-based packages
- document using the shared requirements file in README

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `make lint` *(fails: flake8: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684acd0a9dcc8323b85a8d4793463110