### PR TITLE
Add ingest classification stub and libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project provides a scaffolding for multiple services that work together via
 ## Project Overview
 
  - **services/** – Individual microservices such as `ingest`.
-   A `graph` directory is included only as a placeholder.
+   Additional agents will be added over time.
 - **libs/** – Shared libraries used across services.
 - **docker-compose.yml** – Orchestrates services during development.
 - **Makefile** – Convenience commands for building and running containers.
@@ -39,6 +39,12 @@ where pull requests should target when merging new features or fixes.
 - Modify or add code inside the appropriate service directory.
 - Use the Makefile targets to build and run services locally.
 - Continuous integration is handled via GitHub Actions in `.github/workflows/ci.yml`.
+
+### Ingest Service
+
+The `ingest` service exposes a `POST /alerts` endpoint which classifies
+incoming alerts using a simple LLM-based stub and publishes the result to the
+internal message bus.
 
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 version: '3.8'
-# services:
-#   ingest:
-#     build: ./services/ingest
-#     volumes:
-#       - ./services/ingest:/app
-#   graph:
-#     build: ./services/graph
-#     volumes:
-#       - ./services/graph:/app
+services:
+  ingest:
+    build: ./services/ingest
+    volumes:
+      - ./services/ingest:/app
+      - ./libs:/libs
+    environment:
+      - INGEST_PORT=8000
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-dummy}
+    ports:
+      - "8000:8000"
 

--- a/libs/agentsdk/__init__.py
+++ b/libs/agentsdk/__init__.py
@@ -1,0 +1,9 @@
+"""Agent SDK for common helper functions (stub)."""
+
+from typing import Any
+
+
+def publish_event(topic: str, event: dict) -> None:
+    """Publish an event to message bus (stub)."""
+    import logging
+    logging.getLogger(__name__).info("Publish to %s: %s", topic, event)

--- a/libs/attackkit/__init__.py
+++ b/libs/attackkit/__init__.py
@@ -1,0 +1,3 @@
+from .parser import AttackParser
+
+__all__ = ["AttackParser"]

--- a/libs/attackkit/parser.py
+++ b/libs/attackkit/parser.py
@@ -1,0 +1,24 @@
+class AttackParser:
+    """Parse ATT&CK JSON data (stub)."""
+
+    def __init__(self, path: str | None = None):
+        self.path = path
+        self.data = {}
+        if path:
+            self.load(path)
+
+    def load(self, path: str) -> None:
+        """Load data from given JSON path."""
+        self.path = path
+        try:
+            import json
+            with open(path, 'r', encoding='utf-8') as f:
+                self.data = json.load(f)
+        except FileNotFoundError:
+            self.data = {}
+
+    def get_techniques(self) -> list:
+        """Return list of technique IDs."""
+        if not self.data:
+            return []
+        return [obj.get('id') for obj in self.data.get('objects', []) if obj.get('type') == 'attack-pattern']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 httpx
 uvicorn
+openai

--- a/services/ingest/Dockerfile
+++ b/services/ingest/Dockerfile
@@ -3,4 +3,6 @@ WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
+COPY ../../libs /libs
+ENV PYTHONPATH="/app:/libs"
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/ingest/requirements.txt
+++ b/services/ingest/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 httpx
+openai

--- a/services/ingest/tests/test_api.py
+++ b/services/ingest/tests/test_api.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from app.main import app
+from app.main import Alert, app, classify_alert
 
 client = TestClient(app)
 
@@ -8,11 +8,23 @@ def test_post_alerts():
     payload = {"id": "1", "description": "test alert", "severity": 5}
     response = client.post("/alerts", json=payload)
     assert response.status_code == 200
-    assert response.json() == {"status": "received"}
+    assert response.json()["status"] == "received"
+    assert "technique_id" in response.json()
+    assert "asset_id" in response.json()
 
 
 def test_receive_alert():
     payload = {"id": "1", "description": "test", "severity": 5}
     response = client.post("/alerts", json=payload)
     assert response.status_code == 200
-    assert response.json() == {"status": "received"}
+    body = response.json()
+    assert body["status"] == "received"
+    assert "technique_id" in body
+    assert "asset_id" in body
+
+
+def test_classify_alert():
+    alert = Alert(id="a", description="malware", severity=3)
+    result = classify_alert(alert)
+    assert result.technique_id == "T0001"
+    assert result.asset_id == "asset-123"


### PR DESCRIPTION
## Summary
- scaffold shared libs `attackkit` and `agentsdk`
- update ingest service with LLM-based alert classification stub
- extend ingest API tests for classification data
- expose ingest container via docker-compose
- document ingest service in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `flake8 services` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1d202968832396d815401aa3cfb7